### PR TITLE
Add public API for farmland discount data

### DIFF
--- a/scripts/options.lua
+++ b/scripts/options.lua
@@ -550,6 +550,39 @@ function getDiscountPrice(farmland)
 	end
 	return delta, disct
 end
+
+--------------------- public API for other mods --------------------------------------------------------
+-- Returns farmland discount data for use by external mods (e.g. UsedPlus, FS25_Financing).
+-- Avoids other mods having to access BetterContracts internals directly.
+-- @param farmland  table      farmland object (from g_farmlandManager)
+-- @param farmId    number|nil farm ID, defaults to g_localPlayer.farmId
+-- @return number delta           discount amount (currency)
+-- @return number discountPercent discount as integer (e.g. 15 for 15%)
+-- @return number jobCount        jobs completed for this NPC
+-- @return number maxJobs         max jobs that count toward discount
+function BetterContracts:getFarmlandDiscount(farmland, farmId)
+	if not self.config.discountMode then return 0, 0, 0, 0 end
+	if farmland == nil then return 0, 0, 0, 0 end
+
+	local discPerJob = self.config.discPerJob
+	local discMaxJobs = self.config.discMaxJobs
+	local fId = farmId or g_localPlayer.farmId
+	local farm = g_farmManager:getFarmById(fId)
+	if farm == nil then return 0, 0, 0, 0 end
+
+	local jobs = farm.stats.npcJobs or {}
+	local count = jobs[farmland.npcIndex] or 0
+	local disJobs = math.min(count, discMaxJobs, math.floor(0.5 / discPerJob))
+
+	local delta = 0
+	local discountPercent = 0
+	if disJobs > 0 then
+		delta = farmland.price * disJobs * discPerJob
+		discountPercent = math.floor(100 * disJobs * discPerJob)
+	end
+	return delta, discountPercent, count, discMaxJobs
+end
+
 function showContextBox(box, hotspot, description, image, uvs, farmId, farmText, p27, p28, isFarmBox)
 	-- appended to InGameMenuMapUtil.showContextBox()
 	if box == nil then return end 


### PR DESCRIPTION
## Summary

Adds a single public method `BetterContracts:getFarmlandDiscount(farmland, farmId)` that other mods can call to read a player's earned farmland discounts without accessing BetterContracts internal data structures.

**Context:** I develop [UsedPlus](https://github.com/XelaNull/FS25_UsedPlus), a finance/marketplace mod that overrides the farmland buy button with an enhanced purchase dialog. When both mods are installed, UsedPlus intercepts the buy flow — which means BC's discount never gets applied, and players lose their hard-earned contract discounts. That's a bad experience.

To fix this, we currently replicate BC's discount formula by reading `BetterContracts.config.discPerJob`, `farm.stats.npcJobs`, etc. directly. It works, but it's fragile — if you change those internals, our integration breaks silently.

This PR adds a clean public method that any mod can call instead:

```lua
local delta, pct, jobs, maxJobs = BetterContracts:getFarmlandDiscount(farmland, farmId)
-- delta = 12500 (discount amount)
-- pct = 15 (percent as integer)
-- jobs = 3 (contracts completed for this NPC)
-- maxJobs = 5 (max that count)
```

## What it does

- Wraps the existing discount calculation (same formula as `getDiscountPrice()`)
- Returns richer data: amount, percent, job count, and max jobs
- Accepts optional `farmId` parameter for multiplayer support (defaults to local player)
- Defensive: returns `0, 0, 0, 0` if discount mode is off, farmland is nil, or farm not found
- Zero changes to existing BC functionality

## Why it benefits BC

- **Any mod** that overrides farmland purchasing can read BC discounts through a stable interface
- **Future-proof** — if you refactor internals, the API contract stays the same
- **Multiplayer-friendly** — `farmId` parameter supports non-local player scenarios
- Tiny change (~30 lines), zero risk to existing behavior

## Files changed

- `scripts/options.lua` — Added `BetterContracts:getFarmlandDiscount()` method after the existing `getDiscountPrice()` function

Thank you for Better Contracts — it's a great mod and our players love using it alongside UsedPlus!