### PR TITLE
fix: guard m.field in onConnectionFinishedLoading (:471) — non-field missions reach it unguarded

### DIFF
--- a/scripts/missionVehicles.lua
+++ b/scripts/missionVehicles.lua
@@ -467,8 +467,8 @@ function(self, connection)
 	-- a new client connected. Inform them about active mission vehicles
 	for _, m in ipairs(g_missionManager.missions) do
 		if m.sendLeasedVecs then 
-			debugPrint("* onConnectionFinishedLoading %s %s, vehicles: %d", m:getTitle(), 
-				m.field:getName(), #m.vehicles)
+			debugPrint("* onConnectionFinishedLoading %s %s, vehicles: %d", m:getTitle(),
+				m.field and m.field:getName() or "", #m.vehicles)
 			checkMissionVecs(m, connection)		
 		end
 	end


### PR DESCRIPTION
## The problem

`missionVehicles.lua:471` dereferences `m.field` without a guard, on the server's client-join path:

```lua
-- missionVehicles.lua:464-474, appended to FSBaseMission.onConnectionFinishedLoading
for _, m in ipairs(g_missionManager.missions) do
    if m.sendLeasedVecs then
        debugPrint("* onConnectionFinishedLoading %s %s, vehicles: %d", m:getTitle(),
            m.field:getName(), #m.vehicles)          -- :471
        checkMissionVecs(m, connection)
    end
end
```

`sendLeasedVecs` is set in exactly one place, and the predicate there does **not** require a field:

```lua
-- missionVehicles.lua:444-448
if m.activeMissionId ~= nil and m.spawnedVehicles then          -- no field condition
debugPrint("** %s %s activeId %s", m:getTitle(), m.field and m:getField():getName(), ...)  -- :445, guarded
    m.sendLeasedVecs = true
    if not isMP then checkMissionVecs(m)
```

So the same mission set that you guard at `:445` reaches `:471` unguarded, 26 lines later.

`spawnedVehicles` is not field-specific — it lives on `AbstractMission`, which is also the class this mod hooks: `betterContracts.lua:349` does `Utility.overwrittenFunction(AbstractMission, "init", abstractInit)`. Non-field missions (`treeTransportMission`, `deadwoodMission`, `destructibleRockMission`, `kommunalMission`, `supplyTransportMission`, `woodChipsMission` — the list you keep at `betterContracts.lua:1004-1005`) can therefore satisfy the predicate at `:444` while `m.field` is nil.

**`debugPrint` does not protect this.** The `config.debug` check happens *inside* the function, after Lua has already evaluated the arguments:

```lua
-- betterContracts.lua:119-123
function debugPrint(text, ...)
    if BetterContracts.config and BetterContracts.config.debug then
        Logging.info(text,...)
    end
end
```

So `m.field:getName()` runs regardless of the debug setting, i.e. also in the default configuration.

## What it costs

A Lua error inside the appended `onConnectionFinishedLoading` handler, once a client joins a MP game whose savegame has an active non-field mission with spawned leasing vehicles. The `for` loop aborts at that mission, so `checkMissionVecs(m, connection)` never runs for it or for any mission after it in the list — the joining client doesn't get those leased-vehicle tags.

This is MP-only by construction: `:447` (`if not isMP then checkMissionVecs(m) end`) is what defers the MP case to `:464` in the first place.

## The fix

Guard it exactly the way you already do at `:421` (`local fieldNo = m.field and m.field:getName() or ""`) and at `:445`.

## Honesty about verification

- **Proven by reading this repo**, on `5fe124a` (v1.3.0.8): the unguarded deref, the predicate that admits non-field missions, the `AbstractMission` hook, and the eager-argument behaviour of `debugPrint` are all in the code above. The receiver of the event sent at `:472` also guards the same expression (`missionVehicles.lua:421`).
- **Not reproduced in-game.** I found this by auditing my server's mod set, not by hitting the error. I run a dedicated server with BetterContracts and haven't caught this in my logs — my savegame may simply not have had a qualifying mission active during a join.
- I'm deliberately **not** claiming this hangs or breaks a join. `Utils.appendedFunction` runs the original first, so the base join work is already done by the time this fires; whether the caller does anything critical afterwards, I can't tell without the engine source, so I won't assert it. What's certain is the exception and the lost leased-vehicle sync from that mission onward.
- No syntax check attached: `luac` can't parse this repo at all (`continue` at `missionVehicles.lua:278` is a GIANTS extension, and the unmodified file fails the same way), so it would be a meaningless claim here.
